### PR TITLE
fix: binding value to sql side, as PostGIS doesn't support a whole geojson Feature object, but only `.geometry` object

### DIFF
--- a/geojsonchemy/__init__.py
+++ b/geojsonchemy/__init__.py
@@ -65,7 +65,7 @@ class Geomdantic(_GISType):
         
         def process(value: Optional[Geometry]) -> Optional[str]:
             if value is not None:
-                return value.model_dump_json()
+                return value.geometry.model_dump_json()
 
         return process
 


### PR DESCRIPTION
Geodantic field type caused a following error:

```
Error #48
This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (sqlalchemy.dialects.postgresql.asyncpg.InternalServerError) <class 'asyncpg.exceptions.InternalServerError'>: invalid GeoJson representation
[SQL: INSERT INTO public.map_notes (geom, name, description, type, plan_id) VALUES (ST_GeomFromGeoJSON($1), $2::VARCHAR, $3::VARCHAR, $4::mapnotetype, $5::VARCHAR) RETURNING public.map_notes.id]
[parameters: ('{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[100.00842642715781,13.37308573818055],[100.01275979025621,13.343794810567445],[100.05837413865856,13.352005504954334],[100.05290041684975,13.384179857404305],[100.00842642715781,13.37308573818055]]]},"properties":{}}', 'แผนที่ 1', '', 'hand_draw', 'SKM-MS-67-002')]
(Background on this error at: https://sqlalche.me/e/20/2j85) (Background on this error at: https://sqlalche.me/e/20/7s2a)
```

as you can see, PostgreSQL tries to parse geometry data from geojson `$1` = 
```json
{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[100.00842642715781,13.37308573818055],[100.01275979025621,13.343794810567445],[100.05837413865856,13.352005504954334],[100.05290041684975,13.384179857404305],[100.00842642715781,13.37308573818055]]]},"properties":{}}
```

which [documentation](https://postgis.net/docs/ST_GeomFromGeoJSON.html) has clearly states that only `{"type": "Polygon" ...` is only supported.